### PR TITLE
chore(typos): Fix some typos

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -54,7 +54,7 @@ impl Style {
         self
     }
 
-    /// Show a dotted border arround the display.
+    /// Show a dotted border around the display.
     /// ```
     /// use badgemagic::protocol::Style;
     /// # (
@@ -241,7 +241,7 @@ impl Timestamp {
 
 /// Buffer to create a payload
 ///
-/// A payload consits of up to 8 messages
+/// A payload consists of up to 8 messages
 /// ```
 /// # #[cfg(feature = "embedded-graphics")]
 /// # fn main() {
@@ -368,7 +368,7 @@ impl PayloadBuffer {
         &self.data
     }
 
-    /// Convert the payload buffe into bytes (with padding)
+    /// Convert the payload buffer into bytes (with padding)
     #[allow(clippy::missing_panics_doc)] // should never panic
     #[must_use]
     pub fn into_padded_bytes(self) -> impl AsRef<[u8]> {

--- a/src/usb_hid.rs
+++ b/src/usb_hid.rs
@@ -29,7 +29,7 @@ pub struct Device {
 }
 
 impl Device {
-    /// Return a list of all usb devies as a string representation
+    /// Return a list of all usb devices as a string representation
     pub fn list_all() -> Result<Vec<String>> {
         let api = HidApi::new().context("create hid api")?;
         let devices = api.device_list();


### PR DESCRIPTION
Fixed some typos in `src/protcol.rs` and `src/usb_hid.rs`.

## Summary by Sourcery

Bug Fixes:
- Fixed typos in comments and documentation within the `protocol.rs` and `usb_hid.rs` files.