### PR TITLE
Add support for controlling LED panel brightness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "badgemagic"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "badgemagic"
-version = "0.1.0"
-authors = ["Martin Michaelis <code@mgjm.de>"]
+version = "0.2.0"
+authors = ["Martin Michaelis <code@mgjm.de>", "Valentin Weber <weva+code@kabelsalat.ch>"]
 edition = "2021"
 description = "Badge Magic with LEDs - Library and CLI"
 homepage = "https://badgemagic.fossasia.org"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,5 @@
 Copyright 2024 Martin Michaelis
+Copyright 2025 Valentin Weber
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to deal

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -5,13 +5,13 @@ use badgemagic::{
     embedded_graphics::{
         geometry::Point, mono_font::MonoTextStyle, pixelcolor::BinaryColor, text::Text,
     },
-    protocol::{Mode, PayloadBuffer, Style},
+    protocol::{Brightness, Mode, PayloadBuffer, Style},
     usb_hid::Device,
     util::DrawableLayoutExt,
 };
 
 fn main() -> Result<()> {
-    let mut payload = PayloadBuffer::new();
+    let mut payload = PayloadBuffer::new(Brightness::default());
 
     payload.add_message_drawable(
         Style::default().mode(Mode::Center),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{fs, path::PathBuf};
 use anyhow::{Context, Result};
 use badgemagic::{
     ble::Device as BleDevice,
-    protocol::{Mode, PayloadBuffer, Speed, Style},
+    protocol::{Brightness, Mode, PayloadBuffer, Speed, Style},
     usb_hid::Device as UsbDevice,
 };
 use base64::Engine;
@@ -42,6 +42,10 @@ struct Args {
     /// Transport protocol to use
     #[clap(long)]
     transport: TransportProtocol,
+
+    /// Brightness of the panel
+    #[clap(long)]
+    brightness: Option<Brightness>,
 
     /// List all devices visible to a transport and exit
     #[clap(long)]
@@ -146,7 +150,7 @@ fn gnerate_payload(args: &mut Args) -> Result<PayloadBuffer> {
         }
     };
 
-    let mut payload = PayloadBuffer::new();
+    let mut payload = PayloadBuffer::new(args.brightness.unwrap_or_default());
 
     for message in config.messages {
         let mut style = Style::default();
@@ -164,6 +168,7 @@ fn gnerate_payload(args: &mut Args) -> Result<PayloadBuffer> {
                     Point::new(0, 7),
                     MonoTextStyle::new(&FONT_6X9, BinaryColor::On),
                 );
+
                 payload.add_message_drawable(style, &text);
             }
             Content::Bitstring { bitstring } => {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -509,9 +509,8 @@ impl DrawTarget for MessageBuffer<'_> {
 
 #[cfg(test)]
 mod test {
+    use super::{Brightness, Speed};
     use std::ops::Range;
-
-    use super::Speed;
 
     #[test]
     fn speed_to_u8_and_back() {
@@ -522,6 +521,20 @@ mod test {
             } else {
                 assert!(!VALID_SPEED_VALUES.contains(&i));
             }
+        }
+    }
+
+    #[test]
+    fn brightness_to_u8() {
+        const VALID_BRIGHTNESS_VALUES: [(Brightness, u8); 4] = [
+            (Brightness::Full, 0x00),
+            (Brightness::ThreeQuarters, 0x10),
+            (Brightness::Half, 0x20),
+            (Brightness::OneQuarter, 0x30),
+        ];
+
+        for i in VALID_BRIGHTNESS_VALUES {
+            assert_eq!(u8::from(Brightness::from(i.0)), i.1);
         }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Adds support for controlling the brightness of the LED panel. A new `Brightness` enum is introduced in the protocol, and the `PayloadBuffer` is updated to accept a `Brightness` value during initialization. A new `--brightness` argument is added to the CLI to control the brightness of the panel.

New Features:
- Adds support for controlling the brightness of the LED panel.

Enhancements:
- Updates the `PayloadBuffer` to accept a `Brightness` value during initialization, allowing control over the panel's brightness.
- Updates the magic bytes to be 5 bytes instead of 6.

Build:
- Increments the crate version to 0.2.0.

Documentation:
- Fixes a typo in a comment, changing 'arround' to 'around'.

## Summary by Sourcery

Adds support for controlling the LED panel brightness. A new `Brightness` enum is introduced, and the `PayloadBuffer` is updated to accept a `Brightness` value during initialization. A new `--brightness` argument is added to the CLI to control the brightness of the panel.

New Features:
- Adds support for controlling the LED panel brightness via a new `Brightness` enum and a `--brightness` CLI argument.

Enhancements:
- Updates the `PayloadBuffer` to accept a `Brightness` value during initialization.

Build:
- Increments the crate version to 0.2.0.

Chores:
- Updates the magic bytes to be 5 bytes instead of 6.