### PR TITLE
fix: writing data via usb on windows

### DIFF
--- a/src/usb_hid.rs
+++ b/src/usb_hid.rs
@@ -131,6 +131,10 @@ fn write_raw(device: &HidDevice, data: &[u8]) -> Result<()> {
 fn prepend_byte_and_offset(data: &[u8], offset: usize) -> [u8; 65] {
     let mut result: [u8; 65] = [0u8; 65];
     result[1] = 0x0;
-    result[1..].copy_from_slice(&data[offset..offset + 64]);
+    if data.len() - offset < 64 {
+        result[1..].copy_from_slice(&data[offset..]);
+    } else {
+        result[1..].copy_from_slice(&data[offset..offset + 64]);
+    }
     result
 }

--- a/src/usb_hid.rs
+++ b/src/usb_hid.rs
@@ -131,6 +131,9 @@ fn write_raw(device: &HidDevice, data: &[u8]) -> Result<()> {
 fn prepend_byte_and_offset(data: &[u8], offset: usize) -> [u8; 65] {
     let mut result: [u8; 65] = [0u8; 65];
     result[1] = 0x0;
+    if offset > data.len() {
+        return result;
+    }
     if data.len() - offset < 64 {
         result[1..].copy_from_slice(&data[offset..]);
     } else {

--- a/src/usb_hid.rs
+++ b/src/usb_hid.rs
@@ -101,17 +101,19 @@ fn write_raw(device: &HidDevice, data: &[u8]) -> Result<()> {
     // just to be sure
     assert!(data.len() <= 8192);
 
-    let mut written: usize;
+    let written: usize;
 
     #[cfg(windows)]
     {
-        written = 0;
+        let mut total_written = 0;
 
-        while written < data.len() {
-            let new_data: &[u8] = &prepend_byte_and_offset(data, written);
+        while total_written < data.len() {
+            let new_data: &[u8] = &prepend_byte_and_offset(data, total_written);
             let n = device.write(new_data).context("write payload")?;
-            written = written + n - 1;
+            total_written = total_written + n - 1;
         }
+
+        written = total_written;
     }
 
     #[cfg(not(windows))]

--- a/src/usb_hid.rs
+++ b/src/usb_hid.rs
@@ -101,7 +101,7 @@ fn write_raw(device: &HidDevice, data: &[u8]) -> Result<()> {
     // just to be sure
     assert!(data.len() <= 8192);
 
-    let mut written: usize = 0;
+    let mut written: usize;
 
     #[cfg(windows)]
     {
@@ -128,6 +128,7 @@ fn write_raw(device: &HidDevice, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
+#[cfg(windows)]
 fn prepend_byte_and_offset(data: &[u8], offset: usize) -> [u8; 65] {
     let mut result: [u8; 65] = [0u8; 65];
     result[1] = 0x0;

--- a/src/usb_hid.rs
+++ b/src/usb_hid.rs
@@ -101,13 +101,36 @@ fn write_raw(device: &HidDevice, data: &[u8]) -> Result<()> {
     // just to be sure
     assert!(data.len() <= 8192);
 
-    let n = device.write(data).context("write payload")?;
+    let mut written: usize = 0;
+
+    #[cfg(windows)]
+    {
+        written = 0;
+
+        while written < data.len() {
+            let new_data: &[u8] = &prepend_byte_and_offset(data, written);
+            let n = device.write(new_data).context("write payload")?;
+            written = written + n - 1;
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        written = device.write(data).context("write payload")?;
+    }
 
     anyhow::ensure!(
-        n == data.len(),
-        "incomplete write: {n} of {} bytes",
+        written == data.len(),
+        "incomplete write: {written} of {} bytes",
         data.len()
     );
 
     Ok(())
+}
+
+fn prepend_byte_and_offset(data: &[u8], offset: usize) -> [u8; 65] {
+    let mut result: [u8; 65] = [0u8; 65];
+    result[1] = 0x0;
+    result[1..].copy_from_slice(&data[offset..offset + 64]);
+    result
 }


### PR DESCRIPTION
ref #25  
Seems to have been a combination of both. This works on my machine

## Summary by Sourcery

Handle platform-specific USB HID write behavior to ensure complete payloads are written, particularly on Windows.

Bug Fixes:
- Fix incomplete USB HID writes on Windows by chunking payloads into 64-byte reports with a leading prefix byte and looping until all data is sent.

Enhancements:
- Add a helper to construct HID output reports with a leading prefix byte and sliced payload data, and track the total bytes written across platforms.