### PR TITLE
Fix GIF dimension validation error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ fn generate_payload(args: &mut Args) -> Result<PayloadBuffer> {
                 let frame_count = frames.len();
                 let (width, height) = frames.first().unwrap().buffer().dimensions();
                 if height != DISPLAY_HEIGHT || width != DISPLAY_WIDTH {
-                    anyhow::bail!("Expected {DISPLAY_WIDTH}x{DISPLAY_WIDTH} pixel gif file");
+                    anyhow::bail!("Expected {DISPLAY_WIDTH}x{DISPLAY_HEIGHT} pixel gif file");
                 }
 
                 let mut buffer = payload.add_message(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the GIF dimension validation message to reference the correct expected height value.